### PR TITLE
Schedule Ingresses based on destination Service

### DIFF
--- a/pkg/reconciler/ingress/controller.go
+++ b/pkg/reconciler/ingress/controller.go
@@ -176,12 +176,13 @@ func (c *Controller) process(key string) error {
 
 	if !exists {
 		klog.Infof("Object with key %q was deleted", key)
+		// If Envoy is enabled, delete the Ingress from the config cache.
 		if c.envoyXDS != nil {
 			// if EnvoyXDS is enabled, delete the Ingress from the cache and set the new snaphost.
 			c.cache.DeleteIngress(key)
 			c.envoyXDS.SetSnapshot(envoy.NodeID, c.cache.ToEnvoySnapshot())
 		}
-		// The ingress has been deleted, so we remove any tracking.
+		// The ingress has been deleted, so we remove any ingress to service tracking.
 		c.tracker.deleteIngress(key)
 		return nil
 	}

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -129,15 +129,12 @@ func (c *Controller) createLeafs(ctx context.Context, root *networkingv1.Ingress
 	for _, service := range services {
 		if service.Labels[clusterLabel] != "" {
 			clusterDests = append(clusterDests, service.Labels[clusterLabel])
+			// Trigger reconciliation of the root ingress when this service changes.
+			c.tracker.add(root, service)
 		} else {
 			klog.Infof("Skipping service %q because it is not assigned to any cluster", service.Name)
 		}
 	}
-
-	// cls, err := c.clusterLister.List(labels.Everything())
-	// if err != nil {
-	// 	return err
-	// }
 
 	if len(clusterDests) == 0 {
 		// No status conditions... let's just leave it blank for now.

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -54,7 +54,7 @@ func (c *Controller) reconcile(ctx context.Context, ingress *networkingv1.Ingres
 			}
 		}
 
-		// TODO(jmprusi): ugly. fix. use indexer...
+		// TODO(jmprusi): ugly. fix. use indexer, etc.
 		// Create and/or update the desired leaves
 		for _, desiredleaf := range desiredLeaves {
 			if _, err := c.kubeClient.NetworkingV1().Ingresses(desiredleaf.Namespace).Create(ctx, desiredleaf, metav1.CreateOptions{}); err != nil {
@@ -165,11 +165,12 @@ func (c *Controller) desiredLeaves(ctx context.Context, root *networkingv1.Ingre
 	for _, service := range services {
 		if service.Labels[clusterLabel] != "" {
 			clusterDests = append(clusterDests, service.Labels[clusterLabel])
-			// Trigger reconciliation of the root ingress when this service changes.
-			c.tracker.add(root, service)
 		} else {
 			klog.Infof("Skipping service %q because it is not assigned to any cluster", service.Name)
 		}
+
+		// Trigger reconciliation of the root ingress when this service changes.
+		c.tracker.add(root, service)
 	}
 
 	if len(clusterDests) == 0 {

--- a/pkg/reconciler/ingress/tracker.go
+++ b/pkg/reconciler/ingress/tracker.go
@@ -1,0 +1,69 @@
+package ingress
+
+import (
+	"sync"
+
+	networkingv1 "k8s.io/api/networking/v1"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+type Tracker struct {
+	mu                sync.Mutex
+	trackedServices   map[string][]networkingv1.Ingress
+	ingressToServices map[string]map[string]struct{}
+}
+
+func NewTracker() *Tracker {
+	return &Tracker{
+		trackedServices:   make(map[string][]networkingv1.Ingress),
+		ingressToServices: make(map[string]map[string]struct{}),
+	}
+}
+
+func (t *Tracker) getIngress(service *v1.Service) ([]networkingv1.Ingress, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	s, ok := t.trackedServices[serviceToKey(service)]
+	return s, ok
+}
+
+func (t *Tracker) add(ingress *networkingv1.Ingress, s *v1.Service) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for _, ti := range t.trackedServices[serviceToKey(s)] {
+		if ingressToKey(&ti) == ingressToKey(ingress) {
+			return
+		}
+	}
+	t.trackedServices[serviceToKey(s)] = append(t.trackedServices[serviceToKey(s)], *ingress)
+	t.ingressToServices[ingressToKey(ingress)] = make(map[string]struct{})
+	t.ingressToServices[ingressToKey(ingress)][serviceToKey(s)] = struct{}{}
+}
+
+func (t *Tracker) deleteIngress(ingressKey string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	for serviceKey := range t.ingressToServices[ingressKey] {
+		for i, ing := range t.trackedServices[serviceKey] {
+			if ingressToKey(&ing) == ingressKey {
+				t.trackedServices[serviceKey] = append(t.trackedServices[serviceKey][:i], t.trackedServices[serviceKey][i+1:]...)
+				break
+			}
+		}
+		// This service is no longer being tracked by another ingress, so let's delete it.
+		if len(t.trackedServices[serviceKey]) == 0 {
+			delete(t.trackedServices, serviceKey)
+		}
+	}
+	delete(t.ingressToServices, ingressKey)
+}
+
+func serviceToKey(service *v1.Service) string {
+	return service.Namespace + "/" + service.ClusterName + "#$#" + service.Name
+}
+
+func ingressToKey(ingress *networkingv1.Ingress) string {
+	return ingress.Namespace + "/" + ingress.ClusterName + "#$#" + ingress.Name
+}

--- a/pkg/reconciler/ingress/tracker.go
+++ b/pkg/reconciler/ingress/tracker.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/klog"
 
 	v1 "k8s.io/api/core/v1"
 )
@@ -31,6 +32,7 @@ func (t *Tracker) getIngress(service *v1.Service) ([]networkingv1.Ingress, bool)
 func (t *Tracker) add(ingress *networkingv1.Ingress, s *v1.Service) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	klog.Infof("tracking service %q for ingress %q", s.Name, ingress.Name)
 	for _, ti := range t.trackedServices[serviceToKey(s)] {
 		if ingressToKey(&ti) == ingressToKey(ingress) {
 			return

--- a/utils/local-setup.sh
+++ b/utils/local-setup.sh
@@ -109,7 +109,7 @@ kubectl annotate ingressclass nginx "ingressclass.kubernetes.io/is-default-class
 } &>/dev/null
 
 echo "Starting KCP, sending logs to ${KCP_LOG_FILE}"
-${KCP_BIN} start --push_mode --install_cluster_controller --resources_to_sync=ingresses.networking.k8s.io --auto_publish_apis > ${KCP_LOG_FILE} 2>&1 &
+${KCP_BIN} start --push_mode --install_cluster_controller --resources_to_sync=services --resources_to_sync=ingresses.networking.k8s.io --auto_publish_apis > ${KCP_LOG_FILE} 2>&1 &
 KCP_PID=$!
 
 echo "Waiting 15 seconds..."


### PR DESCRIPTION
This PR makes the `kcp-ingress` controller to create a leaf Ingress assigned to the same cluster as it destination Service.


